### PR TITLE
Update to docker named volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ This repository contains the tooling necessary to bootstrap zkSync locally.
 
 ## Dependencies
 
-To run zkSync locally, you must have `docker-compose` and `Docker` installed on your machine. 
+To run zkSync locally, you must have `docker compose` and `Docker` installed on your machine. 
 
 ## Usage
 
-To bootstrap zkSync locally, run the `start.sh` script:
+To bootstrap zkSync locally, just run:
 
 ```
-> ./start.sh
+> docker compose up
 ```
 
 This command will bootstrap three docker containers:
@@ -25,16 +25,18 @@ By default, the HTTP JSON-RPC API will run on port `3050`, while WS API will run
 
 ## Resetting zkSync state
 
-To reset the zkSync state, run the `./clear.sh` script:
+To reset the zkSync state, just run:
 
 ```
-> ./clear.sh
+> docker compose down --volumes
 ```
 
-Note, that you may receive a "permission denied" error when running this command. In this case, you should run it with the root privileges:
+This command will stop and remove all of the pods and named volumes that contains the network state
+
+After this, you can run again:
 
 ```
-> sudo ./clear.sh
+> docker compose up
 ```
 
 ## Rich wallets

--- a/clear.sh
+++ b/clear.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 
-docker-compose down
-rm -rf ./volumes
+docker-compose down --volumes
 docker-compose pull

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,7 @@ services:
       - "8545:8545"
       - "8546:8546"
     volumes:
-      - type: bind
-        source: ./volumes/geth
-        target: /var/lib/geth/data
+      - geth:/var/lib/geth/data
   postgres:
     image: "postgres:12"
     logging:
@@ -18,9 +16,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - type: bind
-        source: ./volumes/postgres
-        target: /var/lib/postgresql/data
+      - postgres:/var/lib/postgresql/data
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
   zksync:
@@ -35,13 +31,15 @@ services:
       - "3051:3051" # JSON RPC WS port
     volumes:
       # Configs folder bind
-      - type: bind
-        source: ./volumes/zksync/env.env
-        target: /etc/env/dev.env
+      - zksync-config:/etc/env/
       # Storage folder bind
-      - type: bind
-        source: ./volumes/zksync/data
-        target: /var/lib/zksync/data
+      - zksync-data:/var/lib/zksync/data
     environment:
       - DATABASE_URL=postgres://postgres@postgres/zksync_local
       - ETH_CLIENT_WEB3_URL=http://geth:8545
+
+volumes:
+  geth:
+  postgres:
+  zksync-config:
+  zksync-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,6 @@ services:
     image: "postgres:12"
     logging:
       driver: none 
-    ports:
-      - "5432:5432"
     volumes:
       - postgres:/var/lib/postgresql/data
     environment:

--- a/start.sh
+++ b/start.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
 
-mkdir -p ./volumes
-mkdir -p ./volumes/postgres ./volumes/geth ./volumes/zksync/env/dev ./volumes/zksync/data
-touch ./volumes/zksync/env.env
-
 docker-compose up
 


### PR DESCRIPTION
This pr deprecates the use of scripts to handle volumes. Docker-named volumes are used instead now. This leaves state handling to docker, solving some bugs that used to happen when trying to stop and start the nodes again.