### PR TITLE
fix: increase the number of zksync health check retries

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       test: curl --fail http://localhost:3071/health || exit 1
       interval: 10s
       timeout: 5s
-      retries: 20
+      retries: 200
       start_period: 30s
     depends_on:
       - reth


### PR DESCRIPTION
What:
Increase the number of zksync health check retries in the docker compose config.

Why:
The current number of retries is insufficient to spin up the node and deploy all contracts. As a result, the node is considered unhealthy, and other projects can't use the `docker --wait` flag to wait for the node to become healthy, e.g:
```
docker compose up -d --build --wait --wait-timeout 2000
```
Locally, the process took just over 10 minutes, while the current setting is `10 * 20 = 200` sec. This issue has already been addressed in [zk-chains-docker-compose.yml](https://github.com/matter-labs/local-setup/blob/main/zk-chains-docker-compose.yml#L76), but it was likely overlooked in [docker-compose.yml](https://github.com/matter-labs/local-setup/blob/main/docker-compose.yml#L31). With this change, I'm setting the retries to `200`, the same value already used in `zk-chains-docker-compose.yml`.